### PR TITLE
fix(e2e): update home page tests to match actual content

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -4,7 +4,21 @@ export default {
     'scope-enum': [
       2,
       'always',
-      ['cfp', 'planning', 'billing', 'crm', 'api', 'core', 'ui', 'deps', 'config']
+      [
+        'cfp',
+        'planning',
+        'billing',
+        'crm',
+        'api',
+        'core',
+        'ui',
+        'deps',
+        'config',
+        'e2e',
+        'test',
+        'docs',
+        'ci'
+      ]
     ],
     'subject-case': [2, 'always', 'lower-case'],
     'header-max-length': [2, 'always', 100]

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -1,16 +1,34 @@
 import { expect, test } from '@playwright/test'
 
 test.describe('Home Page', () => {
-  test('should display the title and tagline', async ({ page }) => {
+  test('should display the hero section', async ({ page }) => {
     await page.goto('/')
 
-    await expect(page.getByRole('heading', { name: 'Open Event Orchestrator' })).toBeVisible()
-    await expect(page.getByText('The open-source control plane for events')).toBeVisible()
+    await expect(
+      page.getByRole('heading', { name: /open-source control plane for events/i })
+    ).toBeVisible()
+    await expect(page.getByText('all-in-one platform for managing conferences')).toBeVisible()
   })
 
   test('should have correct page title', async ({ page }) => {
     await page.goto('/')
 
-    await expect(page).toHaveTitle('Open Event Orchestrator')
+    await expect(page).toHaveTitle(/Open Event Orchestrator/)
+  })
+
+  test('should display navigation links', async ({ page }) => {
+    await page.goto('/')
+
+    await expect(page.getByRole('link', { name: 'Sign in' })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Get started', exact: true })).toBeVisible()
+  })
+
+  test('should display feature cards', async ({ page }) => {
+    await page.goto('/')
+
+    await expect(page.getByRole('heading', { name: 'Call for Papers' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Planning' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Ticketing' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'CRM' })).toBeVisible()
   })
 })


### PR DESCRIPTION
## Summary

- Fix E2E tests to match actual home page content
- Add missing commit scopes (e2e, test, docs, ci)

## Changes

- Update test selectors to use exact matching and roles
- Add 2 new E2E tests (navigation links, feature cards)
- Extend commitlint scopes for better commit categorization

## Test plan

- [x] All 4 E2E tests pass locally
- [x] Unit tests still pass