### PR TITLE
[#11] feat(cfp): add organizer dashboard for cfp submissions

### DIFF
--- a/src/lib/components/ui/checkbox/checkbox.svelte
+++ b/src/lib/components/ui/checkbox/checkbox.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+import { cn } from '$lib/utils'
+import { Check, Minus } from 'lucide-svelte'
+import type { HTMLInputAttributes } from 'svelte/elements'
+
+interface Props extends Omit<HTMLInputAttributes, 'checked'> {
+  class?: string
+  checked?: boolean | 'indeterminate'
+  onCheckedChange?: (checked: boolean) => void
+}
+
+let {
+  class: className,
+  checked = $bindable(false),
+  onCheckedChange,
+  ...restProps
+}: Props = $props()
+
+function handleChange(e: Event) {
+  const target = e.target as HTMLInputElement
+  checked = target.checked
+  onCheckedChange?.(target.checked)
+}
+</script>
+
+<label class={cn('relative inline-flex cursor-pointer items-center', className)}>
+  <input
+    type="checkbox"
+    checked={checked === true}
+    indeterminate={checked === 'indeterminate'}
+    onchange={handleChange}
+    class="peer sr-only"
+    {...restProps}
+  />
+  <span
+    class="flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border border-primary ring-offset-background peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-ring peer-focus-visible:ring-offset-2 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 peer-checked:bg-primary peer-checked:text-primary-foreground data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground"
+    data-state={checked === 'indeterminate' ? 'indeterminate' : checked ? 'checked' : 'unchecked'}
+  >
+    {#if checked === 'indeterminate'}
+      <Minus class="h-3 w-3" />
+    {:else if checked}
+      <Check class="h-3 w-3" />
+    {/if}
+  </span>
+</label>

--- a/src/lib/components/ui/checkbox/index.ts
+++ b/src/lib/components/ui/checkbox/index.ts
@@ -1,0 +1,3 @@
+import Root from './checkbox.svelte'
+
+export { Root, Root as Checkbox }

--- a/src/lib/components/ui/table/index.ts
+++ b/src/lib/components/ui/table/index.ts
@@ -1,0 +1,22 @@
+import Body from './table-body.svelte'
+import Cell from './table-cell.svelte'
+import Head from './table-head.svelte'
+import Header from './table-header.svelte'
+import Row from './table-row.svelte'
+import Root from './table.svelte'
+
+export {
+  Root,
+  Body,
+  Cell,
+  Head,
+  Header,
+  Row,
+  //
+  Root as Table,
+  Body as TableBody,
+  Cell as TableCell,
+  Head as TableHead,
+  Header as TableHeader,
+  Row as TableRow
+}

--- a/src/lib/components/ui/table/table-body.svelte
+++ b/src/lib/components/ui/table/table-body.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+import { cn } from '$lib/utils'
+import type { Snippet } from 'svelte'
+import type { HTMLAttributes } from 'svelte/elements'
+
+interface Props extends HTMLAttributes<HTMLTableSectionElement> {
+  class?: string
+  children: Snippet
+}
+
+const { class: className, children, ...restProps }: Props = $props()
+</script>
+
+<tbody class={cn('[&_tr:last-child]:border-0', className)} {...restProps}>
+  {@render children()}
+</tbody>

--- a/src/lib/components/ui/table/table-cell.svelte
+++ b/src/lib/components/ui/table/table-cell.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+import { cn } from '$lib/utils'
+import type { Snippet } from 'svelte'
+import type { HTMLTdAttributes } from 'svelte/elements'
+
+interface Props extends HTMLTdAttributes {
+  class?: string
+  children?: Snippet
+}
+
+const { class: className, children, ...restProps }: Props = $props()
+</script>
+
+<td class={cn('p-4 align-middle [&:has([role=checkbox])]:pr-0', className)} {...restProps}>
+  {#if children}
+    {@render children()}
+  {/if}
+</td>

--- a/src/lib/components/ui/table/table-head.svelte
+++ b/src/lib/components/ui/table/table-head.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+import { cn } from '$lib/utils'
+import type { Snippet } from 'svelte'
+import type { HTMLThAttributes } from 'svelte/elements'
+
+interface Props extends HTMLThAttributes {
+  class?: string
+  children?: Snippet
+}
+
+const { class: className, children, ...restProps }: Props = $props()
+</script>
+
+<th
+  class={cn(
+    'h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0',
+    className
+  )}
+  {...restProps}
+>
+  {#if children}
+    {@render children()}
+  {/if}
+</th>

--- a/src/lib/components/ui/table/table-header.svelte
+++ b/src/lib/components/ui/table/table-header.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+import { cn } from '$lib/utils'
+import type { Snippet } from 'svelte'
+import type { HTMLAttributes } from 'svelte/elements'
+
+interface Props extends HTMLAttributes<HTMLTableSectionElement> {
+  class?: string
+  children: Snippet
+}
+
+const { class: className, children, ...restProps }: Props = $props()
+</script>
+
+<thead class={cn('[&_tr]:border-b', className)} {...restProps}>
+  {@render children()}
+</thead>

--- a/src/lib/components/ui/table/table-row.svelte
+++ b/src/lib/components/ui/table/table-row.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+import { cn } from '$lib/utils'
+import type { Snippet } from 'svelte'
+import type { HTMLAttributes } from 'svelte/elements'
+
+interface Props extends HTMLAttributes<HTMLTableRowElement> {
+  class?: string
+  children: Snippet
+}
+
+const { class: className, children, ...restProps }: Props = $props()
+</script>
+
+<tr
+  class={cn(
+    'border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted',
+    className
+  )}
+  {...restProps}
+>
+  {@render children()}
+</tr>

--- a/src/lib/components/ui/table/table.svelte
+++ b/src/lib/components/ui/table/table.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+import { cn } from '$lib/utils'
+import type { Snippet } from 'svelte'
+import type { HTMLTableAttributes } from 'svelte/elements'
+
+interface Props extends HTMLTableAttributes {
+  class?: string
+  children: Snippet
+}
+
+const { class: className, children, ...restProps }: Props = $props()
+</script>
+
+<div class="relative w-full overflow-auto">
+  <table class={cn('w-full caption-bottom text-sm', className)} {...restProps}>
+    {@render children()}
+  </table>
+</div>

--- a/src/lib/features/cfp/ui/index.ts
+++ b/src/lib/features/cfp/ui/index.ts
@@ -1,2 +1,3 @@
 export { default as SpeakerForm } from './speaker-form.svelte'
+export { default as StatusBadge } from './status-badge.svelte'
 export { default as TalkForm } from './talk-form.svelte'

--- a/src/lib/features/cfp/ui/status-badge.svelte
+++ b/src/lib/features/cfp/ui/status-badge.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+import { type TalkStatus, getStatusColor, getStatusLabel } from '$lib/features/cfp/domain'
+import { cn } from '$lib/utils'
+
+interface Props {
+  status: TalkStatus
+  class?: string
+}
+
+const { status, class: className }: Props = $props()
+
+const colorClasses: Record<string, string> = {
+  gray: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300',
+  blue: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300',
+  yellow: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300',
+  green: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300',
+  red: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300',
+  emerald: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-300',
+  orange: 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-300',
+  slate: 'bg-slate-100 text-slate-800 dark:bg-slate-800 dark:text-slate-300'
+}
+
+const color = $derived(getStatusColor(status))
+const label = $derived(getStatusLabel(status))
+</script>
+
+<span
+  class={cn(
+    'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
+    colorClasses[color],
+    className
+  )}
+>
+  {label}
+</span>

--- a/src/routes/admin/cfp/+page.server.ts
+++ b/src/routes/admin/cfp/+page.server.ts
@@ -1,0 +1,22 @@
+import type { PageServerLoad } from './$types'
+
+export const load: PageServerLoad = async ({ locals }) => {
+  // For now, get all published editions
+  // In the future, this should be filtered by user's organizations
+  const editions = await locals.pb.collection('editions').getFullList({
+    filter: 'status = "published"',
+    sort: '-year'
+  })
+
+  return {
+    editions: editions.map((e) => ({
+      id: e.id as string,
+      name: e.name as string,
+      slug: e.slug as string,
+      year: e.year as number,
+      startDate: new Date(e.startDate as string),
+      endDate: new Date(e.endDate as string),
+      status: e.status as string
+    }))
+  }
+}

--- a/src/routes/admin/cfp/+page.svelte
+++ b/src/routes/admin/cfp/+page.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+import { Button } from '$lib/components/ui/button'
+import * as Card from '$lib/components/ui/card'
+import { ArrowRight, Calendar, FileText } from 'lucide-svelte'
+import type { PageData } from './$types'
+
+interface Props {
+  data: PageData
+}
+
+const { data }: Props = $props()
+
+const formatDate = (date: Date) => {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric'
+  }).format(date)
+}
+</script>
+
+<svelte:head>
+  <title>CFP Management - Open Event Orchestrator</title>
+</svelte:head>
+
+<div class="space-y-6">
+  <div>
+    <h2 class="text-3xl font-bold tracking-tight">CFP Management</h2>
+    <p class="text-muted-foreground">Select an edition to manage its Call for Papers submissions.</p>
+  </div>
+
+  {#if data.editions.length === 0}
+    <Card.Root>
+      <Card.Content class="flex flex-col items-center justify-center py-12">
+        <FileText class="mb-4 h-12 w-12 text-muted-foreground" />
+        <h3 class="text-lg font-semibold">No editions available</h3>
+        <p class="text-sm text-muted-foreground">
+          Create and publish an edition to start managing CFP submissions.
+        </p>
+      </Card.Content>
+    </Card.Root>
+  {:else}
+    <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {#each data.editions as edition}
+        <Card.Root class="transition-shadow hover:shadow-md">
+          <Card.Header>
+            <Card.Title class="flex items-center gap-2">
+              <Calendar class="h-5 w-5" />
+              {edition.name}
+            </Card.Title>
+            <Card.Description>
+              {formatDate(edition.startDate)} - {formatDate(edition.endDate)}
+            </Card.Description>
+          </Card.Header>
+          <Card.Content>
+            <a href="/admin/cfp/{edition.slug}/submissions">
+              <Button class="w-full" variant="outline">
+                Manage Submissions
+                <ArrowRight class="ml-2 h-4 w-4" />
+              </Button>
+            </a>
+          </Card.Content>
+        </Card.Root>
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/src/routes/admin/cfp/[editionSlug]/+layout.server.ts
+++ b/src/routes/admin/cfp/[editionSlug]/+layout.server.ts
@@ -1,0 +1,42 @@
+import { createCategoryRepository, createFormatRepository } from '$lib/features/cfp/infra'
+import { error } from '@sveltejs/kit'
+import type { LayoutServerLoad } from './$types'
+
+export const load: LayoutServerLoad = async ({ params, locals }) => {
+  const categoryRepo = createCategoryRepository(locals.pb)
+  const formatRepo = createFormatRepository(locals.pb)
+
+  // Find edition by slug
+  const editions = await locals.pb.collection('editions').getList(1, 1, {
+    filter: `slug = "${params.editionSlug}"`
+  })
+
+  if (editions.items.length === 0) {
+    throw error(404, 'Edition not found')
+  }
+
+  const editionRecord = editions.items[0]
+
+  const edition = {
+    id: editionRecord.id as string,
+    eventId: editionRecord.eventId as string,
+    name: editionRecord.name as string,
+    slug: editionRecord.slug as string,
+    year: editionRecord.year as number,
+    startDate: new Date(editionRecord.startDate as string),
+    endDate: new Date(editionRecord.endDate as string),
+    venue: editionRecord.venue as string | undefined,
+    city: editionRecord.city as string | undefined,
+    country: editionRecord.country as string | undefined,
+    status: editionRecord.status as 'draft' | 'published' | 'archived'
+  }
+
+  const categories = await categoryRepo.findByEdition(edition.id)
+  const formats = await formatRepo.findByEdition(edition.id)
+
+  return {
+    edition,
+    categories,
+    formats
+  }
+}

--- a/src/routes/admin/cfp/[editionSlug]/submissions/+page.server.ts
+++ b/src/routes/admin/cfp/[editionSlug]/submissions/+page.server.ts
@@ -1,0 +1,171 @@
+import type { TalkStatus } from '$lib/features/cfp/domain'
+import { createSpeakerRepository, createTalkRepository } from '$lib/features/cfp/infra'
+import { fail } from '@sveltejs/kit'
+import type { Actions, PageServerLoad } from './$types'
+
+export const load: PageServerLoad = async ({ parent, url, locals }) => {
+  const { edition, categories, formats } = await parent()
+
+  const talkRepo = createTalkRepository(locals.pb)
+  const speakerRepo = createSpeakerRepository(locals.pb)
+
+  // Get filter params
+  const statusFilter = url.searchParams.get('status')
+  const categoryFilter = url.searchParams.get('category')
+  const formatFilter = url.searchParams.get('format')
+  const search = url.searchParams.get('search')
+  const page = Number.parseInt(url.searchParams.get('page') || '1', 10)
+  const perPage = 20
+
+  // Build filters
+  const filters: {
+    editionId: string
+    status?: TalkStatus | TalkStatus[]
+    categoryId?: string
+    formatId?: string
+  } = {
+    editionId: edition.id
+  }
+
+  if (statusFilter && statusFilter !== 'all') {
+    filters.status = statusFilter as TalkStatus
+  }
+  if (categoryFilter && categoryFilter !== 'all') {
+    filters.categoryId = categoryFilter
+  }
+  if (formatFilter && formatFilter !== 'all') {
+    filters.formatId = formatFilter
+  }
+
+  // Get talks with filters
+  const talks = await talkRepo.findByFilters(filters, { page, perPage })
+
+  // Get speaker data for all talks
+  const speakerIds = [...new Set(talks.flatMap((t) => t.speakerIds))]
+  const speakers = await speakerRepo.findByIds(speakerIds)
+  const speakerMap = new Map(speakers.map((s) => [s.id, s]))
+
+  // Apply search filter (client-side for now, could be optimized with PocketBase search)
+  let filteredTalks = talks
+  if (search) {
+    const searchLower = search.toLowerCase()
+    filteredTalks = talks.filter((talk) => {
+      const titleMatch = talk.title.toLowerCase().includes(searchLower)
+      const speakerMatch = talk.speakerIds.some((id) => {
+        const speaker = speakerMap.get(id)
+        if (!speaker) return false
+        return (
+          speaker.firstName.toLowerCase().includes(searchLower) ||
+          speaker.lastName.toLowerCase().includes(searchLower) ||
+          speaker.email.toLowerCase().includes(searchLower)
+        )
+      })
+      return titleMatch || speakerMatch
+    })
+  }
+
+  // Get counts by status
+  const statusCounts = await talkRepo.countByEdition(edition.id)
+
+  // Map talks with speaker data
+  const talksWithSpeakers = filteredTalks.map((talk) => ({
+    ...talk,
+    speakers: talk.speakerIds.map((id) => speakerMap.get(id)).filter(Boolean),
+    category: categories.find((c) => c.id === talk.categoryId),
+    format: formats.find((f) => f.id === talk.formatId)
+  }))
+
+  return {
+    edition,
+    categories,
+    formats,
+    talks: talksWithSpeakers,
+    statusCounts,
+    filters: {
+      status: statusFilter || 'all',
+      category: categoryFilter || 'all',
+      format: formatFilter || 'all',
+      search: search || ''
+    },
+    pagination: {
+      page,
+      perPage,
+      total: filteredTalks.length
+    }
+  }
+}
+
+export const actions: Actions = {
+  updateStatus: async ({ request, locals }) => {
+    const formData = await request.formData()
+    const talkIds = formData.getAll('talkIds') as string[]
+    const newStatus = formData.get('status') as TalkStatus
+
+    if (!talkIds.length || !newStatus) {
+      return fail(400, { error: 'Missing talk IDs or status' })
+    }
+
+    const talkRepo = createTalkRepository(locals.pb)
+
+    try {
+      await Promise.all(talkIds.map((id) => talkRepo.updateStatus(id, newStatus)))
+      return { success: true, message: `Updated ${talkIds.length} talk(s) to ${newStatus}` }
+    } catch (err) {
+      console.error('Failed to update talks:', err)
+      return fail(500, { error: 'Failed to update talks' })
+    }
+  },
+
+  export: async ({ locals, url }) => {
+    const editionSlug = url.pathname.split('/')[3]
+
+    // Find edition
+    const editions = await locals.pb.collection('editions').getList(1, 1, {
+      filter: `slug = "${editionSlug}"`
+    })
+
+    if (editions.items.length === 0) {
+      return fail(404, { error: 'Edition not found' })
+    }
+
+    const editionId = editions.items[0].id as string
+
+    const talkRepo = createTalkRepository(locals.pb)
+    const speakerRepo = createSpeakerRepository(locals.pb)
+
+    const talks = await talkRepo.findByFilters({ editionId })
+    const speakerIds = [...new Set(talks.flatMap((t) => t.speakerIds))]
+    const speakers = await speakerRepo.findByIds(speakerIds)
+    const speakerMap = new Map(speakers.map((s) => [s.id, s]))
+
+    // Build CSV
+    const headers = [
+      'Title',
+      'Abstract',
+      'Status',
+      'Language',
+      'Level',
+      'Speaker Names',
+      'Speaker Emails',
+      'Submitted At'
+    ]
+
+    const rows = talks.map((talk) => {
+      const talkSpeakers = talk.speakerIds.map((id) => speakerMap.get(id)).filter(Boolean)
+      return [
+        `"${talk.title.replace(/"/g, '""')}"`,
+        `"${talk.abstract.replace(/"/g, '""')}"`,
+        talk.status,
+        talk.language,
+        talk.level || '',
+        `"${talkSpeakers.map((s) => `${s?.firstName} ${s?.lastName}`).join(', ')}"`,
+        `"${talkSpeakers.map((s) => s?.email).join(', ')}"`,
+        talk.submittedAt?.toISOString() || ''
+      ].join(',')
+    })
+
+    const csv = [headers.join(','), ...rows].join('\n')
+
+    return { csv, filename: `cfp-export-${editionSlug}.csv` }
+  }
+}

--- a/src/routes/admin/cfp/[editionSlug]/submissions/+page.svelte
+++ b/src/routes/admin/cfp/[editionSlug]/submissions/+page.svelte
@@ -1,0 +1,395 @@
+<script lang="ts">
+import { enhance } from '$app/forms'
+import { goto } from '$app/navigation'
+import { page } from '$app/stores'
+import { Button } from '$lib/components/ui/button'
+import * as Card from '$lib/components/ui/card'
+import { Checkbox } from '$lib/components/ui/checkbox'
+import { Input } from '$lib/components/ui/input'
+import { Select } from '$lib/components/ui/select'
+import * as Table from '$lib/components/ui/table'
+import { talkStatusSchema } from '$lib/features/cfp/domain'
+import { StatusBadge } from '$lib/features/cfp/ui'
+import { ArrowLeft, Check, Download, FileText, Search, X } from 'lucide-svelte'
+import type { ActionData, PageData } from './$types'
+
+interface Props {
+  data: PageData
+  form: ActionData
+}
+
+const { data, form }: Props = $props()
+
+let selectedIds = $state<Set<string>>(new Set())
+let search = $state('')
+let isExporting = $state(false)
+
+$effect(() => {
+  search = data.filters.search
+})
+
+const allStatuses = talkStatusSchema.options
+
+const allSelected = $derived(data.talks.length > 0 && selectedIds.size === data.talks.length)
+const someSelected = $derived(selectedIds.size > 0 && !allSelected)
+
+function toggleAll() {
+  if (allSelected) {
+    selectedIds = new Set()
+  } else {
+    selectedIds = new Set(data.talks.map((t) => t.id))
+  }
+}
+
+function toggleOne(id: string) {
+  const next = new Set(selectedIds)
+  if (next.has(id)) {
+    next.delete(id)
+  } else {
+    next.add(id)
+  }
+  selectedIds = next
+}
+
+function updateFilter(key: string, value: string) {
+  const url = new URL($page.url)
+  if (value === 'all' || value === '') {
+    url.searchParams.delete(key)
+  } else {
+    url.searchParams.set(key, value)
+  }
+  url.searchParams.delete('page')
+  goto(url.toString(), { replaceState: true })
+}
+
+function handleSearch() {
+  updateFilter('search', search)
+}
+
+function clearSelection() {
+  selectedIds = new Set()
+}
+
+function formatSpeakerNames(
+  speakers: ({ firstName: string; lastName: string } | undefined)[]
+): string {
+  return speakers
+    .filter((s): s is { firstName: string; lastName: string } => s !== undefined)
+    .map((s) => `${s.firstName} ${s.lastName}`)
+    .join(', ')
+}
+
+function formatDate(date: Date | undefined): string {
+  if (!date) return '-'
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  }).format(date)
+}
+
+const totalSubmissions = $derived(Object.values(data.statusCounts).reduce((a, b) => a + b, 0))
+
+$effect(() => {
+  if (form?.csv) {
+    const blob = new Blob([form.csv], { type: 'text/csv' })
+    const url = window.URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = form.filename || 'export.csv'
+    a.click()
+    window.URL.revokeObjectURL(url)
+  }
+})
+</script>
+
+<svelte:head>
+  <title>CFP Submissions - {data.edition.name} - Open Event Orchestrator</title>
+</svelte:head>
+
+<div class="space-y-6">
+  <!-- Header -->
+  <div class="flex items-center justify-between">
+    <div class="flex items-center gap-4">
+      <a href="/admin/cfp">
+        <Button variant="ghost" size="icon">
+          <ArrowLeft class="h-4 w-4" />
+        </Button>
+      </a>
+      <div>
+        <h2 class="text-3xl font-bold tracking-tight">CFP Submissions</h2>
+        <p class="text-muted-foreground">{data.edition.name}</p>
+      </div>
+    </div>
+    <form method="POST" action="?/export" use:enhance={() => {
+      isExporting = true
+      return async ({ update }) => {
+        isExporting = false
+        await update()
+      }
+    }}>
+      <Button variant="outline" type="submit" disabled={isExporting}>
+        <Download class="mr-2 h-4 w-4" />
+        Export CSV
+      </Button>
+    </form>
+  </div>
+
+  {#if form?.error}
+    <div class="rounded-lg border border-destructive bg-destructive/10 p-4">
+      <p class="text-sm text-destructive">{form.error}</p>
+    </div>
+  {/if}
+
+  {#if form?.success}
+    <div class="rounded-lg border border-green-500 bg-green-500/10 p-4">
+      <p class="text-sm text-green-700 dark:text-green-400">{form.message}</p>
+    </div>
+  {/if}
+
+  <!-- Stats Cards -->
+  <div class="grid gap-4 md:grid-cols-4 lg:grid-cols-8">
+    <Card.Root class="col-span-2">
+      <Card.Header class="pb-2">
+        <Card.Title class="text-sm font-medium">Total</Card.Title>
+      </Card.Header>
+      <Card.Content>
+        <div class="text-2xl font-bold">{totalSubmissions}</div>
+      </Card.Content>
+    </Card.Root>
+
+    <Card.Root>
+      <Card.Header class="pb-2">
+        <Card.Title class="text-sm font-medium text-blue-600">Submitted</Card.Title>
+      </Card.Header>
+      <Card.Content>
+        <div class="text-2xl font-bold">{data.statusCounts.submitted}</div>
+      </Card.Content>
+    </Card.Root>
+
+    <Card.Root>
+      <Card.Header class="pb-2">
+        <Card.Title class="text-sm font-medium text-yellow-600">Review</Card.Title>
+      </Card.Header>
+      <Card.Content>
+        <div class="text-2xl font-bold">{data.statusCounts.under_review}</div>
+      </Card.Content>
+    </Card.Root>
+
+    <Card.Root>
+      <Card.Header class="pb-2">
+        <Card.Title class="text-sm font-medium text-green-600">Accepted</Card.Title>
+      </Card.Header>
+      <Card.Content>
+        <div class="text-2xl font-bold">{data.statusCounts.accepted}</div>
+      </Card.Content>
+    </Card.Root>
+
+    <Card.Root>
+      <Card.Header class="pb-2">
+        <Card.Title class="text-sm font-medium text-red-600">Rejected</Card.Title>
+      </Card.Header>
+      <Card.Content>
+        <div class="text-2xl font-bold">{data.statusCounts.rejected}</div>
+      </Card.Content>
+    </Card.Root>
+
+    <Card.Root>
+      <Card.Header class="pb-2">
+        <Card.Title class="text-sm font-medium text-emerald-600">Confirmed</Card.Title>
+      </Card.Header>
+      <Card.Content>
+        <div class="text-2xl font-bold">{data.statusCounts.confirmed}</div>
+      </Card.Content>
+    </Card.Root>
+
+    <Card.Root>
+      <Card.Header class="pb-2">
+        <Card.Title class="text-sm font-medium text-gray-600">Draft</Card.Title>
+      </Card.Header>
+      <Card.Content>
+        <div class="text-2xl font-bold">{data.statusCounts.draft}</div>
+      </Card.Content>
+    </Card.Root>
+  </div>
+
+  <!-- Filters -->
+  <Card.Root>
+    <Card.Content class="pt-6">
+      <div class="flex flex-wrap items-end gap-4">
+        <!-- Search -->
+        <div class="flex-1">
+          <label for="search" class="mb-2 block text-sm font-medium">Search</label>
+          <div class="flex gap-2">
+            <div class="relative flex-1">
+              <Search class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                id="search"
+                type="text"
+                placeholder="Search by title or speaker..."
+                class="pl-10"
+                bind:value={search}
+                onkeydown={(e) => e.key === 'Enter' && handleSearch()}
+              />
+            </div>
+            <Button onclick={handleSearch}>Search</Button>
+          </div>
+        </div>
+
+        <!-- Status Filter -->
+        <div class="w-40">
+          <label for="status-filter" class="mb-2 block text-sm font-medium">Status</label>
+          <Select
+            id="status-filter"
+            value={data.filters.status}
+            onchange={(e) => updateFilter('status', e.currentTarget.value)}
+          >
+            <option value="all">All statuses</option>
+            {#each allStatuses as status}
+              <option value={status}>{status}</option>
+            {/each}
+          </Select>
+        </div>
+
+        <!-- Category Filter -->
+        <div class="w-40">
+          <label for="category-filter" class="mb-2 block text-sm font-medium">Category</label>
+          <Select
+            id="category-filter"
+            value={data.filters.category}
+            onchange={(e) => updateFilter('category', e.currentTarget.value)}
+          >
+            <option value="all">All categories</option>
+            {#each data.categories as category}
+              <option value={category.id}>{category.name}</option>
+            {/each}
+          </Select>
+        </div>
+
+        <!-- Format Filter -->
+        <div class="w-40">
+          <label for="format-filter" class="mb-2 block text-sm font-medium">Format</label>
+          <Select
+            id="format-filter"
+            value={data.filters.format}
+            onchange={(e) => updateFilter('format', e.currentTarget.value)}
+          >
+            <option value="all">All formats</option>
+            {#each data.formats as format}
+              <option value={format.id}>{format.name}</option>
+            {/each}
+          </Select>
+        </div>
+      </div>
+    </Card.Content>
+  </Card.Root>
+
+  <!-- Bulk Actions -->
+  {#if selectedIds.size > 0}
+    <Card.Root class="border-primary bg-primary/5">
+      <Card.Content class="flex items-center justify-between py-3">
+        <span class="text-sm font-medium">{selectedIds.size} talk(s) selected</span>
+        <div class="flex items-center gap-2">
+          <form method="POST" action="?/updateStatus" use:enhance>
+            {#each [...selectedIds] as id}
+              <input type="hidden" name="talkIds" value={id} />
+            {/each}
+            <div class="flex gap-2">
+              <Button type="submit" name="status" value="under_review" variant="outline" size="sm">
+                Start Review
+              </Button>
+              <Button type="submit" name="status" value="accepted" variant="outline" size="sm" class="text-green-600">
+                <Check class="mr-1 h-3 w-3" />
+                Accept
+              </Button>
+              <Button type="submit" name="status" value="rejected" variant="outline" size="sm" class="text-red-600">
+                <X class="mr-1 h-3 w-3" />
+                Reject
+              </Button>
+            </div>
+          </form>
+          <Button variant="ghost" size="sm" onclick={clearSelection}>
+            Clear selection
+          </Button>
+        </div>
+      </Card.Content>
+    </Card.Root>
+  {/if}
+
+  <!-- Table -->
+  <Card.Root>
+    <Table.Root>
+      <Table.Header>
+        <Table.Row>
+          <Table.Head class="w-12">
+            <Checkbox
+              checked={allSelected ? true : someSelected ? 'indeterminate' : false}
+              onCheckedChange={toggleAll}
+            />
+          </Table.Head>
+          <Table.Head>Title</Table.Head>
+          <Table.Head>Speaker(s)</Table.Head>
+          <Table.Head>Category</Table.Head>
+          <Table.Head>Format</Table.Head>
+          <Table.Head>Status</Table.Head>
+          <Table.Head>Submitted</Table.Head>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {#if data.talks.length === 0}
+          <Table.Row>
+            <Table.Cell colspan={7}>
+              <div class="flex flex-col items-center justify-center py-12">
+                <FileText class="mb-4 h-12 w-12 text-muted-foreground" />
+                <h3 class="text-lg font-semibold">No submissions found</h3>
+                <p class="text-sm text-muted-foreground">
+                  {data.filters.search || data.filters.status !== 'all' || data.filters.category !== 'all'
+                    ? 'Try adjusting your filters.'
+                    : 'Submissions will appear here once speakers submit talks.'}
+                </p>
+              </div>
+            </Table.Cell>
+          </Table.Row>
+        {:else}
+          {#each data.talks as talk}
+            <Table.Row data-state={selectedIds.has(talk.id) ? 'selected' : ''}>
+              <Table.Cell>
+                <Checkbox
+                  checked={selectedIds.has(talk.id)}
+                  onCheckedChange={() => toggleOne(talk.id)}
+                />
+              </Table.Cell>
+              <Table.Cell>
+                <a
+                  href="/admin/cfp/{data.edition.slug}/submissions/{talk.id}"
+                  class="font-medium hover:underline"
+                >
+                  {talk.title}
+                </a>
+              </Table.Cell>
+              <Table.Cell>
+                <span class="text-muted-foreground">
+                  {formatSpeakerNames(talk.speakers)}
+                </span>
+              </Table.Cell>
+              <Table.Cell>
+                {talk.category?.name || '-'}
+              </Table.Cell>
+              <Table.Cell>
+                {talk.format?.name || '-'}
+              </Table.Cell>
+              <Table.Cell>
+                <StatusBadge status={talk.status} />
+              </Table.Cell>
+              <Table.Cell class="text-muted-foreground">
+                {formatDate(talk.submittedAt)}
+              </Table.Cell>
+            </Table.Row>
+          {/each}
+        {/if}
+      </Table.Body>
+    </Table.Root>
+  </Card.Root>
+</div>

--- a/src/routes/admin/cfp/[editionSlug]/submissions/[talkId]/+page.server.ts
+++ b/src/routes/admin/cfp/[editionSlug]/submissions/[talkId]/+page.server.ts
@@ -1,0 +1,78 @@
+import type { TalkStatus } from '$lib/features/cfp/domain'
+import { createSpeakerRepository, createTalkRepository } from '$lib/features/cfp/infra'
+import { error, fail, redirect } from '@sveltejs/kit'
+import type { Actions, PageServerLoad } from './$types'
+
+export const load: PageServerLoad = async ({ parent, params, locals }) => {
+  const { edition, categories, formats } = await parent()
+
+  const talkRepo = createTalkRepository(locals.pb)
+  const speakerRepo = createSpeakerRepository(locals.pb)
+
+  const talk = await talkRepo.findById(params.talkId)
+
+  if (!talk) {
+    throw error(404, 'Talk not found')
+  }
+
+  if (talk.editionId !== edition.id) {
+    throw error(404, 'Talk not found in this edition')
+  }
+
+  const speakers = await speakerRepo.findByIds(talk.speakerIds)
+
+  return {
+    edition,
+    categories,
+    formats,
+    talk: {
+      ...talk,
+      category: categories.find((c) => c.id === talk.categoryId),
+      format: formats.find((f) => f.id === talk.formatId)
+    },
+    speakers
+  }
+}
+
+export const actions: Actions = {
+  updateStatus: async ({ request, locals, params }) => {
+    const formData = await request.formData()
+    const newStatus = formData.get('status') as TalkStatus
+
+    if (!newStatus) {
+      return fail(400, { error: 'Status is required' })
+    }
+
+    const talkRepo = createTalkRepository(locals.pb)
+
+    try {
+      await talkRepo.updateStatus(params.talkId, newStatus)
+      return { success: true, message: `Status updated to ${newStatus}` }
+    } catch (err) {
+      console.error('Failed to update talk status:', err)
+      return fail(500, { error: 'Failed to update status' })
+    }
+  },
+
+  delete: async ({ locals, params }) => {
+    const talkRepo = createTalkRepository(locals.pb)
+
+    try {
+      await talkRepo.delete(params.talkId)
+    } catch (err) {
+      console.error('Failed to delete talk:', err)
+      return fail(500, { error: 'Failed to delete talk' })
+    }
+
+    // Find edition slug to redirect back to submissions
+    const editions = await locals.pb.collection('editions').getList(1, 1, {
+      filter: `slug = "${params.editionSlug}"`
+    })
+
+    if (editions.items.length > 0) {
+      throw redirect(303, `/admin/cfp/${params.editionSlug}/submissions`)
+    }
+
+    throw redirect(303, '/admin/cfp')
+  }
+}

--- a/src/routes/admin/cfp/[editionSlug]/submissions/[talkId]/+page.svelte
+++ b/src/routes/admin/cfp/[editionSlug]/submissions/[talkId]/+page.svelte
@@ -1,0 +1,338 @@
+<script lang="ts">
+import { enhance } from '$app/forms'
+import { Button } from '$lib/components/ui/button'
+import * as Card from '$lib/components/ui/card'
+import { talkStatusSchema } from '$lib/features/cfp/domain'
+import { StatusBadge } from '$lib/features/cfp/ui'
+import { ArrowLeft, Check, ExternalLink, Mail, MapPin, Trash2, X } from 'lucide-svelte'
+import type { ActionData, PageData } from './$types'
+
+interface Props {
+  data: PageData
+  form: ActionData
+}
+
+const { data, form }: Props = $props()
+
+let showDeleteConfirm = $state(false)
+
+const allStatuses = talkStatusSchema.options
+
+function formatDate(date: Date | undefined): string {
+  if (!date) return '-'
+  return new Intl.DateTimeFormat('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  }).format(date)
+}
+
+function getLevelLabel(level: string | undefined): string {
+  if (!level) return '-'
+  const labels: Record<string, string> = {
+    beginner: 'Beginner',
+    intermediate: 'Intermediate',
+    advanced: 'Advanced'
+  }
+  return labels[level] || level
+}
+
+function getLanguageLabel(lang: string): string {
+  const labels: Record<string, string> = {
+    fr: 'French',
+    en: 'English'
+  }
+  return labels[lang] || lang
+}
+</script>
+
+<svelte:head>
+  <title>{data.talk.title} - CFP - Open Event Orchestrator</title>
+</svelte:head>
+
+<div class="space-y-6">
+  <!-- Header -->
+  <div class="flex items-start justify-between">
+    <div class="flex items-start gap-4">
+      <a href="/admin/cfp/{data.edition.slug}/submissions">
+        <Button variant="ghost" size="icon" class="mt-1">
+          <ArrowLeft class="h-4 w-4" />
+        </Button>
+      </a>
+      <div>
+        <div class="mb-2 flex items-center gap-3">
+          <h2 class="text-3xl font-bold tracking-tight">{data.talk.title}</h2>
+          <StatusBadge status={data.talk.status} />
+        </div>
+        <p class="text-muted-foreground">{data.edition.name}</p>
+      </div>
+    </div>
+
+    <Button variant="destructive" size="sm" onclick={() => (showDeleteConfirm = true)}>
+      <Trash2 class="mr-2 h-4 w-4" />
+      Delete
+    </Button>
+  </div>
+
+  {#if form?.error}
+    <div class="rounded-lg border border-destructive bg-destructive/10 p-4">
+      <p class="text-sm text-destructive">{form.error}</p>
+    </div>
+  {/if}
+
+  {#if form?.success}
+    <div class="rounded-lg border border-green-500 bg-green-500/10 p-4">
+      <p class="text-sm text-green-700 dark:text-green-400">{form.message}</p>
+    </div>
+  {/if}
+
+  <!-- Delete Confirmation -->
+  {#if showDeleteConfirm}
+    <Card.Root class="border-destructive">
+      <Card.Content class="flex items-center justify-between py-4">
+        <div>
+          <p class="font-medium">Are you sure you want to delete this talk?</p>
+          <p class="text-sm text-muted-foreground">This action cannot be undone.</p>
+        </div>
+        <div class="flex gap-2">
+          <Button variant="outline" onclick={() => (showDeleteConfirm = false)}>Cancel</Button>
+          <form method="POST" action="?/delete" use:enhance>
+            <Button type="submit" variant="destructive">Delete</Button>
+          </form>
+        </div>
+      </Card.Content>
+    </Card.Root>
+  {/if}
+
+  <div class="grid gap-6 lg:grid-cols-3">
+    <!-- Main Content -->
+    <div class="space-y-6 lg:col-span-2">
+      <!-- Talk Details -->
+      <Card.Root>
+        <Card.Header>
+          <Card.Title>Talk Details</Card.Title>
+        </Card.Header>
+        <Card.Content class="space-y-6">
+          <div>
+            <h4 class="mb-2 text-sm font-medium text-muted-foreground">Abstract</h4>
+            <p class="whitespace-pre-wrap">{data.talk.abstract}</p>
+          </div>
+
+          {#if data.talk.description}
+            <div>
+              <h4 class="mb-2 text-sm font-medium text-muted-foreground">Description</h4>
+              <p class="whitespace-pre-wrap">{data.talk.description}</p>
+            </div>
+          {/if}
+
+          {#if data.talk.notes}
+            <div>
+              <h4 class="mb-2 text-sm font-medium text-muted-foreground">Notes for Organizers</h4>
+              <p class="whitespace-pre-wrap rounded-lg bg-muted p-4 text-sm">
+                {data.talk.notes}
+              </p>
+            </div>
+          {/if}
+        </Card.Content>
+      </Card.Root>
+
+      <!-- Speaker(s) -->
+      <Card.Root>
+        <Card.Header>
+          <Card.Title>Speaker{data.speakers.length > 1 ? 's' : ''}</Card.Title>
+        </Card.Header>
+        <Card.Content>
+          <div class="space-y-6">
+            {#each data.speakers as speaker}
+              <div class="flex gap-4">
+                <div
+                  class="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-muted text-2xl font-semibold"
+                >
+                  {speaker.firstName[0]}{speaker.lastName[0]}
+                </div>
+                <div class="flex-1 space-y-2">
+                  <div>
+                    <h4 class="font-semibold">{speaker.firstName} {speaker.lastName}</h4>
+                    {#if speaker.jobTitle || speaker.company}
+                      <p class="text-sm text-muted-foreground">
+                        {#if speaker.jobTitle}{speaker.jobTitle}{/if}
+                        {#if speaker.jobTitle && speaker.company} at {/if}
+                        {#if speaker.company}{speaker.company}{/if}
+                      </p>
+                    {/if}
+                  </div>
+
+                  <div class="flex flex-wrap gap-4 text-sm">
+                    <a
+                      href="mailto:{speaker.email}"
+                      class="flex items-center gap-1 text-muted-foreground hover:text-foreground"
+                    >
+                      <Mail class="h-4 w-4" />
+                      {speaker.email}
+                    </a>
+
+                    {#if speaker.city || speaker.country}
+                      <span class="flex items-center gap-1 text-muted-foreground">
+                        <MapPin class="h-4 w-4" />
+                        {[speaker.city, speaker.country].filter(Boolean).join(', ')}
+                      </span>
+                    {/if}
+                  </div>
+
+                  {#if speaker.twitter || speaker.github || speaker.linkedin}
+                    <div class="flex gap-3">
+                      {#if speaker.twitter}
+                        <a
+                          href="https://twitter.com/{speaker.twitter}"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          class="text-sm text-muted-foreground hover:text-foreground"
+                        >
+                          @{speaker.twitter}
+                        </a>
+                      {/if}
+                      {#if speaker.github}
+                        <a
+                          href="https://github.com/{speaker.github}"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          class="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+                        >
+                          <ExternalLink class="h-3 w-3" />
+                          GitHub
+                        </a>
+                      {/if}
+                      {#if speaker.linkedin}
+                        <a
+                          href="https://linkedin.com/in/{speaker.linkedin}"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          class="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+                        >
+                          <ExternalLink class="h-3 w-3" />
+                          LinkedIn
+                        </a>
+                      {/if}
+                    </div>
+                  {/if}
+
+                  {#if speaker.bio}
+                    <p class="text-sm text-muted-foreground">{speaker.bio}</p>
+                  {/if}
+                </div>
+              </div>
+            {/each}
+          </div>
+        </Card.Content>
+      </Card.Root>
+    </div>
+
+    <!-- Sidebar -->
+    <div class="space-y-6">
+      <!-- Status Actions -->
+      <Card.Root>
+        <Card.Header>
+          <Card.Title>Status</Card.Title>
+        </Card.Header>
+        <Card.Content class="space-y-4">
+          <div class="flex items-center gap-2">
+            <span class="text-sm text-muted-foreground">Current:</span>
+            <StatusBadge status={data.talk.status} />
+          </div>
+
+          <form method="POST" action="?/updateStatus" use:enhance class="space-y-2">
+            <p class="text-sm font-medium">Quick Actions</p>
+            <div class="flex flex-wrap gap-2">
+              {#if data.talk.status === 'submitted'}
+                <Button type="submit" name="status" value="under_review" variant="outline" size="sm">
+                  Start Review
+                </Button>
+              {/if}
+              {#if ['submitted', 'under_review'].includes(data.talk.status)}
+                <Button
+                  type="submit"
+                  name="status"
+                  value="accepted"
+                  variant="outline"
+                  size="sm"
+                  class="text-green-600"
+                >
+                  <Check class="mr-1 h-3 w-3" />
+                  Accept
+                </Button>
+                <Button
+                  type="submit"
+                  name="status"
+                  value="rejected"
+                  variant="outline"
+                  size="sm"
+                  class="text-red-600"
+                >
+                  <X class="mr-1 h-3 w-3" />
+                  Reject
+                </Button>
+              {/if}
+            </div>
+
+            <div class="pt-2">
+              <p class="mb-2 text-sm font-medium">Change Status</p>
+              <div class="flex flex-wrap gap-1">
+                {#each allStatuses as status}
+                  <Button
+                    type="submit"
+                    name="status"
+                    value={status}
+                    variant={data.talk.status === status ? 'secondary' : 'ghost'}
+                    size="sm"
+                    class="text-xs"
+                    disabled={data.talk.status === status}
+                  >
+                    {status}
+                  </Button>
+                {/each}
+              </div>
+            </div>
+          </form>
+        </Card.Content>
+      </Card.Root>
+
+      <!-- Metadata -->
+      <Card.Root>
+        <Card.Header>
+          <Card.Title>Information</Card.Title>
+        </Card.Header>
+        <Card.Content>
+          <dl class="space-y-3 text-sm">
+            <div class="flex justify-between">
+              <dt class="text-muted-foreground">Category</dt>
+              <dd class="font-medium">{data.talk.category?.name || '-'}</dd>
+            </div>
+            <div class="flex justify-between">
+              <dt class="text-muted-foreground">Format</dt>
+              <dd class="font-medium">{data.talk.format?.name || '-'}</dd>
+            </div>
+            <div class="flex justify-between">
+              <dt class="text-muted-foreground">Language</dt>
+              <dd class="font-medium">{getLanguageLabel(data.talk.language)}</dd>
+            </div>
+            <div class="flex justify-between">
+              <dt class="text-muted-foreground">Level</dt>
+              <dd class="font-medium">{getLevelLabel(data.talk.level)}</dd>
+            </div>
+            <div class="border-t pt-3">
+              <dt class="mb-1 text-muted-foreground">Submitted</dt>
+              <dd class="font-medium">{formatDate(data.talk.submittedAt)}</dd>
+            </div>
+            <div>
+              <dt class="mb-1 text-muted-foreground">Created</dt>
+              <dd class="font-medium">{formatDate(data.talk.createdAt)}</dd>
+            </div>
+          </dl>
+        </Card.Content>
+      </Card.Root>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary

- Add admin interface for managing CFP submissions
- Edition selection page at `/admin/cfp`
- Submissions list with DataTable at `/admin/cfp/[editionSlug]/submissions`
- Talk detail page at `/admin/cfp/[editionSlug]/submissions/[talkId]`
- Filter by status, category, and format
- Search by title or speaker name
- Bulk status updates (accept, reject, start review)
- CSV export functionality
- Status badges with color coding
- New UI components: Table, Checkbox, StatusBadge

## Test plan

- [ ] Navigate to `/admin/cfp` and see list of editions
- [ ] Click on an edition to see submissions list
- [ ] Test filters (status, category, format)
- [ ] Test search functionality
- [ ] Select multiple talks and test bulk actions
- [ ] Test CSV export
- [ ] Click on a talk to see detail view
- [ ] Test status change from detail view
- [ ] Test delete functionality

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)