### PR TITLE
feat(cfp): add notification system for speaker communications

### DIFF
--- a/src/lib/features/cfp/domain/index.ts
+++ b/src/lib/features/cfp/domain/index.ts
@@ -27,6 +27,17 @@ export {
 } from './format'
 
 export {
+  notificationTypeSchema,
+  emailLogSchema,
+  createEmailLogSchema,
+  getNotificationTypeLabel,
+  getNotificationSubject,
+  type NotificationType,
+  type EmailLog,
+  type CreateEmailLog
+} from './notification'
+
+export {
   speakerSchema,
   createSpeakerSchema,
   updateSpeakerSchema,

--- a/src/lib/features/cfp/domain/notification.test.ts
+++ b/src/lib/features/cfp/domain/notification.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createEmailLogSchema,
+  emailLogSchema,
+  getNotificationSubject,
+  getNotificationTypeLabel,
+  notificationTypeSchema
+} from './notification'
+
+describe('notification domain', () => {
+  describe('notificationTypeSchema', () => {
+    it('should accept valid notification types', () => {
+      const types = [
+        'submission_confirmed',
+        'talk_accepted',
+        'talk_rejected',
+        'confirmation_reminder',
+        'cfp_closing_reminder'
+      ]
+      for (const type of types) {
+        expect(notificationTypeSchema.safeParse(type).success).toBe(true)
+      }
+    })
+
+    it('should reject invalid notification types', () => {
+      expect(notificationTypeSchema.safeParse('invalid').success).toBe(false)
+      expect(notificationTypeSchema.safeParse('').success).toBe(false)
+    })
+  })
+
+  describe('emailLogSchema', () => {
+    it('should validate a complete email log', () => {
+      const log = {
+        id: 'log-1',
+        talkId: 'talk-1',
+        speakerId: 'speaker-1',
+        editionId: 'edition-1',
+        type: 'talk_accepted',
+        to: 'speaker@example.com',
+        subject: 'Your talk was accepted',
+        sentAt: new Date(),
+        status: 'sent'
+      }
+
+      expect(emailLogSchema.safeParse(log).success).toBe(true)
+    })
+
+    it('should accept log without talkId', () => {
+      const log = {
+        id: 'log-1',
+        speakerId: 'speaker-1',
+        editionId: 'edition-1',
+        type: 'cfp_closing_reminder',
+        to: 'speaker@example.com',
+        subject: 'CFP closing soon',
+        sentAt: new Date(),
+        status: 'sent'
+      }
+
+      expect(emailLogSchema.safeParse(log).success).toBe(true)
+    })
+
+    it('should accept log with error', () => {
+      const log = {
+        id: 'log-1',
+        speakerId: 'speaker-1',
+        editionId: 'edition-1',
+        type: 'talk_accepted',
+        to: 'speaker@example.com',
+        subject: 'Subject',
+        sentAt: new Date(),
+        status: 'failed',
+        error: 'SMTP connection failed'
+      }
+
+      expect(emailLogSchema.safeParse(log).success).toBe(true)
+    })
+
+    it('should reject invalid email', () => {
+      const log = {
+        id: 'log-1',
+        speakerId: 'speaker-1',
+        editionId: 'edition-1',
+        type: 'talk_accepted',
+        to: 'invalid-email',
+        subject: 'Subject',
+        sentAt: new Date(),
+        status: 'sent'
+      }
+
+      expect(emailLogSchema.safeParse(log).success).toBe(false)
+    })
+
+    it('should reject invalid status', () => {
+      const log = {
+        id: 'log-1',
+        speakerId: 'speaker-1',
+        editionId: 'edition-1',
+        type: 'talk_accepted',
+        to: 'speaker@example.com',
+        subject: 'Subject',
+        sentAt: new Date(),
+        status: 'invalid'
+      }
+
+      expect(emailLogSchema.safeParse(log).success).toBe(false)
+    })
+  })
+
+  describe('createEmailLogSchema', () => {
+    it('should validate creation data without id and sentAt', () => {
+      const data = {
+        speakerId: 'speaker-1',
+        editionId: 'edition-1',
+        type: 'submission_confirmed',
+        to: 'speaker@example.com',
+        subject: 'Submission received',
+        status: 'pending'
+      }
+
+      expect(createEmailLogSchema.safeParse(data).success).toBe(true)
+    })
+  })
+
+  describe('getNotificationTypeLabel', () => {
+    it('should return correct labels', () => {
+      expect(getNotificationTypeLabel('submission_confirmed')).toBe('Submission Confirmed')
+      expect(getNotificationTypeLabel('talk_accepted')).toBe('Talk Accepted')
+      expect(getNotificationTypeLabel('talk_rejected')).toBe('Talk Rejected')
+      expect(getNotificationTypeLabel('confirmation_reminder')).toBe('Confirmation Reminder')
+      expect(getNotificationTypeLabel('cfp_closing_reminder')).toBe('CFP Closing Reminder')
+    })
+  })
+
+  describe('getNotificationSubject', () => {
+    it('should generate submission confirmed subject', () => {
+      const subject = getNotificationSubject('submission_confirmed', 'DevFest 2024')
+      expect(subject).toBe('[DevFest 2024] Your talk submission has been received')
+    })
+
+    it('should generate talk accepted subject with title', () => {
+      const subject = getNotificationSubject('talk_accepted', 'DevFest 2024', 'My Awesome Talk')
+      expect(subject).toBe(
+        '[DevFest 2024] Congratulations! Your talk "My Awesome Talk" has been accepted'
+      )
+    })
+
+    it('should generate talk rejected subject with title', () => {
+      const subject = getNotificationSubject('talk_rejected', 'DevFest 2024', 'My Talk')
+      expect(subject).toBe('[DevFest 2024] Update on your talk submission "My Talk"')
+    })
+
+    it('should generate confirmation reminder subject with title', () => {
+      const subject = getNotificationSubject('confirmation_reminder', 'DevFest 2024', 'My Talk')
+      expect(subject).toBe('[DevFest 2024] Please confirm your participation for "My Talk"')
+    })
+
+    it('should generate cfp closing reminder subject', () => {
+      const subject = getNotificationSubject('cfp_closing_reminder', 'DevFest 2024')
+      expect(subject).toBe('[DevFest 2024] CFP closing soon - Submit your talk!')
+    })
+  })
+})

--- a/src/lib/features/cfp/domain/notification.ts
+++ b/src/lib/features/cfp/domain/notification.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod'
+
+export const notificationTypeSchema = z.enum([
+  'submission_confirmed',
+  'talk_accepted',
+  'talk_rejected',
+  'confirmation_reminder',
+  'cfp_closing_reminder'
+])
+
+export type NotificationType = z.infer<typeof notificationTypeSchema>
+
+export const emailLogSchema = z.object({
+  id: z.string(),
+  talkId: z.string().optional(),
+  speakerId: z.string(),
+  editionId: z.string(),
+  type: notificationTypeSchema,
+  to: z.string().email(),
+  subject: z.string(),
+  sentAt: z.date(),
+  status: z.enum(['sent', 'failed', 'pending']),
+  error: z.string().optional()
+})
+
+export type EmailLog = z.infer<typeof emailLogSchema>
+
+export const createEmailLogSchema = emailLogSchema.omit({
+  id: true,
+  sentAt: true
+})
+
+export type CreateEmailLog = z.infer<typeof createEmailLogSchema>
+
+export const getNotificationTypeLabel = (type: NotificationType): string => {
+  const labels: Record<NotificationType, string> = {
+    submission_confirmed: 'Submission Confirmed',
+    talk_accepted: 'Talk Accepted',
+    talk_rejected: 'Talk Rejected',
+    confirmation_reminder: 'Confirmation Reminder',
+    cfp_closing_reminder: 'CFP Closing Reminder'
+  }
+  return labels[type]
+}
+
+export const getNotificationSubject = (
+  type: NotificationType,
+  editionName: string,
+  talkTitle?: string
+): string => {
+  const subjects: Record<NotificationType, string> = {
+    submission_confirmed: `[${editionName}] Your talk submission has been received`,
+    talk_accepted: `[${editionName}] Congratulations! Your talk "${talkTitle}" has been accepted`,
+    talk_rejected: `[${editionName}] Update on your talk submission "${talkTitle}"`,
+    confirmation_reminder: `[${editionName}] Please confirm your participation for "${talkTitle}"`,
+    cfp_closing_reminder: `[${editionName}] CFP closing soon - Submit your talk!`
+  }
+  return subjects[type]
+}

--- a/src/lib/features/cfp/infra/email-log-repository.ts
+++ b/src/lib/features/cfp/infra/email-log-repository.ts
@@ -1,0 +1,100 @@
+import type PocketBase from 'pocketbase'
+import type { CreateEmailLog, EmailLog, NotificationType } from '../domain'
+
+const COLLECTION = 'email_logs'
+
+export const createEmailLogRepository = (pb: PocketBase) => ({
+  async findById(id: string): Promise<EmailLog | null> {
+    try {
+      const record = await pb.collection(COLLECTION).getOne(id)
+      return mapRecordToEmailLog(record)
+    } catch {
+      return null
+    }
+  },
+
+  async findByTalk(talkId: string): Promise<EmailLog[]> {
+    const records = await pb.collection(COLLECTION).getFullList({
+      filter: `talkId = "${talkId}"`,
+      sort: '-sentAt'
+    })
+    return records.map(mapRecordToEmailLog)
+  },
+
+  async findBySpeaker(speakerId: string): Promise<EmailLog[]> {
+    const records = await pb.collection(COLLECTION).getFullList({
+      filter: `speakerId = "${speakerId}"`,
+      sort: '-sentAt'
+    })
+    return records.map(mapRecordToEmailLog)
+  },
+
+  async findByEdition(editionId: string): Promise<EmailLog[]> {
+    const records = await pb.collection(COLLECTION).getFullList({
+      filter: `editionId = "${editionId}"`,
+      sort: '-sentAt'
+    })
+    return records.map(mapRecordToEmailLog)
+  },
+
+  async findByType(editionId: string, type: NotificationType): Promise<EmailLog[]> {
+    const records = await pb.collection(COLLECTION).getFullList({
+      filter: `editionId = "${editionId}" && type = "${type}"`,
+      sort: '-sentAt'
+    })
+    return records.map(mapRecordToEmailLog)
+  },
+
+  async create(data: CreateEmailLog): Promise<EmailLog> {
+    const record = await pb.collection(COLLECTION).create({
+      ...data,
+      sentAt: new Date().toISOString()
+    })
+    return mapRecordToEmailLog(record)
+  },
+
+  async updateStatus(
+    id: string,
+    status: 'sent' | 'failed' | 'pending',
+    error?: string
+  ): Promise<EmailLog> {
+    const record = await pb.collection(COLLECTION).update(id, { status, error })
+    return mapRecordToEmailLog(record)
+  },
+
+  async countByEdition(editionId: string): Promise<Record<string, number>> {
+    const records = await pb.collection(COLLECTION).getFullList({
+      filter: `editionId = "${editionId}"`,
+      fields: 'type,status'
+    })
+
+    const counts: Record<string, number> = {
+      total: records.length,
+      sent: 0,
+      failed: 0,
+      pending: 0
+    }
+
+    for (const record of records) {
+      const status = record.status as string
+      counts[status] = (counts[status] || 0) + 1
+    }
+
+    return counts
+  }
+})
+
+const mapRecordToEmailLog = (record: Record<string, unknown>): EmailLog => ({
+  id: record.id as string,
+  talkId: record.talkId as string | undefined,
+  speakerId: record.speakerId as string,
+  editionId: record.editionId as string,
+  type: record.type as NotificationType,
+  to: record.to as string,
+  subject: record.subject as string,
+  sentAt: new Date(record.sentAt as string),
+  status: record.status as 'sent' | 'failed' | 'pending',
+  error: record.error as string | undefined
+})
+
+export type EmailLogRepository = ReturnType<typeof createEmailLogRepository>

--- a/src/lib/features/cfp/infra/index.ts
+++ b/src/lib/features/cfp/infra/index.ts
@@ -1,5 +1,6 @@
 export { createCategoryRepository, type CategoryRepository } from './category-repository'
 export { createCommentRepository, type CommentRepository } from './comment-repository'
+export { createEmailLogRepository, type EmailLogRepository } from './email-log-repository'
 export { createFormatRepository, type FormatRepository } from './format-repository'
 export { createReviewRepository, type ReviewRepository } from './review-repository'
 export { createSpeakerRepository, type SpeakerRepository } from './speaker-repository'

--- a/src/lib/features/cfp/services/email-service.ts
+++ b/src/lib/features/cfp/services/email-service.ts
@@ -1,0 +1,233 @@
+import type { NotificationType } from '../domain/notification'
+
+export interface EmailOptions {
+  to: string
+  subject: string
+  html: string
+  text?: string
+}
+
+export interface EmailService {
+  send(options: EmailOptions): Promise<{ success: boolean; error?: string }>
+}
+
+export interface EmailTemplateData {
+  speakerName: string
+  talkTitle?: string
+  editionName: string
+  eventName: string
+  cfpUrl?: string
+  confirmationUrl?: string
+  cfpDeadline?: string
+}
+
+export const createConsoleEmailService = (): EmailService => ({
+  async send(options: EmailOptions) {
+    console.log('=== Email Sent (Console) ===')
+    console.log('To:', options.to)
+    console.log('Subject:', options.subject)
+    console.log('Body:', options.text || options.html)
+    console.log('===========================')
+    return { success: true }
+  }
+})
+
+export const createResendEmailService = (apiKey: string): EmailService => ({
+  async send(options: EmailOptions) {
+    try {
+      const response = await fetch('https://api.resend.com/emails', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          from: 'CFP <cfp@notifications.example.com>',
+          to: options.to,
+          subject: options.subject,
+          html: options.html,
+          text: options.text
+        })
+      })
+
+      if (!response.ok) {
+        const error = await response.text()
+        return { success: false, error }
+      }
+
+      return { success: true }
+    } catch (err) {
+      return { success: false, error: String(err) }
+    }
+  }
+})
+
+export const generateEmailHtml = (type: NotificationType, data: EmailTemplateData): string => {
+  const templates: Record<NotificationType, string> = {
+    submission_confirmed: `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Submission Confirmed</title>
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+  <h1 style="color: #2563eb;">Thank you for your submission!</h1>
+  <p>Dear ${data.speakerName},</p>
+  <p>We have received your talk submission <strong>"${data.talkTitle}"</strong> for <strong>${data.editionName}</strong>.</p>
+  <p>Our team will review your proposal and get back to you soon.</p>
+  <p>You can view and manage your submissions here:</p>
+  <p><a href="${data.cfpUrl}" style="display: inline-block; background: #2563eb; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px;">View My Submissions</a></p>
+  <p>Best regards,<br>The ${data.eventName} Team</p>
+</body>
+</html>`,
+
+    talk_accepted: `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Talk Accepted</title>
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+  <h1 style="color: #16a34a;">Congratulations! Your talk has been accepted!</h1>
+  <p>Dear ${data.speakerName},</p>
+  <p>We are thrilled to inform you that your talk <strong>"${data.talkTitle}"</strong> has been accepted for <strong>${data.editionName}</strong>!</p>
+  <p>Please confirm your participation by clicking the button below:</p>
+  <p><a href="${data.confirmationUrl}" style="display: inline-block; background: #16a34a; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px;">Confirm My Participation</a></p>
+  <p>We look forward to seeing you at the event!</p>
+  <p>Best regards,<br>The ${data.eventName} Team</p>
+</body>
+</html>`,
+
+    talk_rejected: `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Talk Status Update</title>
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+  <h1 style="color: #64748b;">Thank you for your submission</h1>
+  <p>Dear ${data.speakerName},</p>
+  <p>Thank you for submitting your talk <strong>"${data.talkTitle}"</strong> to <strong>${data.editionName}</strong>.</p>
+  <p>After careful consideration, we regret to inform you that we were unable to include your talk in this year's program. We received many excellent proposals, and the selection process was challenging.</p>
+  <p>We encourage you to submit again for future editions!</p>
+  <p>Best regards,<br>The ${data.eventName} Team</p>
+</body>
+</html>`,
+
+    confirmation_reminder: `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Confirmation Reminder</title>
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+  <h1 style="color: #f59e0b;">Please confirm your participation</h1>
+  <p>Dear ${data.speakerName},</p>
+  <p>This is a friendly reminder that your talk <strong>"${data.talkTitle}"</strong> has been accepted for <strong>${data.editionName}</strong>, but we haven't received your confirmation yet.</p>
+  <p>Please confirm your participation as soon as possible:</p>
+  <p><a href="${data.confirmationUrl}" style="display: inline-block; background: #f59e0b; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px;">Confirm My Participation</a></p>
+  <p>Best regards,<br>The ${data.eventName} Team</p>
+</body>
+</html>`,
+
+    cfp_closing_reminder: `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CFP Closing Soon</title>
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+  <h1 style="color: #dc2626;">CFP Closing Soon!</h1>
+  <p>Dear ${data.speakerName},</p>
+  <p>This is a reminder that the Call for Papers for <strong>${data.editionName}</strong> is closing on <strong>${data.cfpDeadline}</strong>.</p>
+  <p>Don't miss your chance to submit a talk!</p>
+  <p><a href="${data.cfpUrl}" style="display: inline-block; background: #dc2626; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px;">Submit a Talk Now</a></p>
+  <p>Best regards,<br>The ${data.eventName} Team</p>
+</body>
+</html>`
+  }
+
+  return templates[type]
+}
+
+export const generateEmailText = (type: NotificationType, data: EmailTemplateData): string => {
+  const templates: Record<NotificationType, string> = {
+    submission_confirmed: `
+Thank you for your submission!
+
+Dear ${data.speakerName},
+
+We have received your talk submission "${data.talkTitle}" for ${data.editionName}.
+
+Our team will review your proposal and get back to you soon.
+
+You can view and manage your submissions here: ${data.cfpUrl}
+
+Best regards,
+The ${data.eventName} Team`,
+
+    talk_accepted: `
+Congratulations! Your talk has been accepted!
+
+Dear ${data.speakerName},
+
+We are thrilled to inform you that your talk "${data.talkTitle}" has been accepted for ${data.editionName}!
+
+Please confirm your participation here: ${data.confirmationUrl}
+
+We look forward to seeing you at the event!
+
+Best regards,
+The ${data.eventName} Team`,
+
+    talk_rejected: `
+Thank you for your submission
+
+Dear ${data.speakerName},
+
+Thank you for submitting your talk "${data.talkTitle}" to ${data.editionName}.
+
+After careful consideration, we regret to inform you that we were unable to include your talk in this year's program. We received many excellent proposals, and the selection process was challenging.
+
+We encourage you to submit again for future editions!
+
+Best regards,
+The ${data.eventName} Team`,
+
+    confirmation_reminder: `
+Please confirm your participation
+
+Dear ${data.speakerName},
+
+This is a friendly reminder that your talk "${data.talkTitle}" has been accepted for ${data.editionName}, but we haven't received your confirmation yet.
+
+Please confirm your participation here: ${data.confirmationUrl}
+
+Best regards,
+The ${data.eventName} Team`,
+
+    cfp_closing_reminder: `
+CFP Closing Soon!
+
+Dear ${data.speakerName},
+
+This is a reminder that the Call for Papers for ${data.editionName} is closing on ${data.cfpDeadline}.
+
+Don't miss your chance to submit a talk: ${data.cfpUrl}
+
+Best regards,
+The ${data.eventName} Team`
+  }
+
+  return templates[type].trim()
+}

--- a/src/lib/features/cfp/services/index.ts
+++ b/src/lib/features/cfp/services/index.ts
@@ -1,0 +1,9 @@
+export {
+  createConsoleEmailService,
+  createResendEmailService,
+  generateEmailHtml,
+  generateEmailText,
+  type EmailService,
+  type EmailOptions,
+  type EmailTemplateData
+} from './email-service'

--- a/src/lib/features/cfp/usecases/index.ts
+++ b/src/lib/features/cfp/usecases/index.ts
@@ -18,3 +18,10 @@ export {
   type GetSpeakerSubmissionsResult,
   type GetSpeakerSubmissionsUseCase
 } from './get-speaker-submissions'
+
+export {
+  createSendNotificationUseCase,
+  type SendNotificationInput,
+  type SendNotificationResult,
+  type SendNotificationUseCase
+} from './send-notification'

--- a/src/lib/features/cfp/usecases/send-notification.ts
+++ b/src/lib/features/cfp/usecases/send-notification.ts
@@ -1,0 +1,94 @@
+import type { NotificationType } from '../domain'
+import { getNotificationSubject } from '../domain/notification'
+import type { EmailLogRepository } from '../infra/email-log-repository'
+import type { SpeakerRepository } from '../infra/speaker-repository'
+import type { TalkRepository } from '../infra/talk-repository'
+import type { EmailService, EmailTemplateData } from '../services/email-service'
+import { generateEmailHtml, generateEmailText } from '../services/email-service'
+
+export interface SendNotificationInput {
+  type: NotificationType
+  talkId?: string
+  speakerId: string
+  editionId: string
+  editionName: string
+  eventName: string
+  baseUrl: string
+}
+
+export interface SendNotificationResult {
+  success: boolean
+  emailLogId?: string
+  error?: string
+}
+
+export const createSendNotificationUseCase = (
+  emailService: EmailService,
+  emailLogRepository: EmailLogRepository,
+  speakerRepository: SpeakerRepository,
+  talkRepository: TalkRepository
+) => {
+  return async (input: SendNotificationInput): Promise<SendNotificationResult> => {
+    // Get speaker info
+    const speaker = await speakerRepository.findById(input.speakerId)
+    if (!speaker) {
+      return { success: false, error: 'Speaker not found' }
+    }
+
+    // Get talk info if provided
+    let talkTitle: string | undefined
+    if (input.talkId) {
+      const talk = await talkRepository.findById(input.talkId)
+      if (talk) {
+        talkTitle = talk.title
+      }
+    }
+
+    // Build template data
+    const templateData: EmailTemplateData = {
+      speakerName: `${speaker.firstName} ${speaker.lastName}`,
+      talkTitle,
+      editionName: input.editionName,
+      eventName: input.eventName,
+      cfpUrl: `${input.baseUrl}/cfp/${input.editionId}/submissions?email=${encodeURIComponent(speaker.email)}`,
+      confirmationUrl: input.talkId
+        ? `${input.baseUrl}/cfp/${input.editionId}/submissions/${input.talkId}/confirm`
+        : undefined
+    }
+
+    // Generate email content
+    const subject = getNotificationSubject(input.type, input.editionName, talkTitle)
+    const html = generateEmailHtml(input.type, templateData)
+    const text = generateEmailText(input.type, templateData)
+
+    // Create pending email log
+    const emailLog = await emailLogRepository.create({
+      talkId: input.talkId,
+      speakerId: input.speakerId,
+      editionId: input.editionId,
+      type: input.type,
+      to: speaker.email,
+      subject,
+      status: 'pending'
+    })
+
+    // Send email
+    const result = await emailService.send({
+      to: speaker.email,
+      subject,
+      html,
+      text
+    })
+
+    // Update email log status
+    if (result.success) {
+      await emailLogRepository.updateStatus(emailLog.id, 'sent')
+      return { success: true, emailLogId: emailLog.id }
+    }
+
+    await emailLogRepository.updateStatus(emailLog.id, 'failed', result.error)
+    return { success: false, emailLogId: emailLog.id, error: result.error }
+  }
+}
+
+export type SendNotificationUseCase = ReturnType<typeof createSendNotificationUseCase>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
         'src/lib/**/index.ts',
         'src/lib/**/infra/**',
         'src/lib/**/usecases/**',
+        'src/lib/**/services/**',
         'src/lib/server/**',
         'src/lib/stores/**',
         'src/lib/utils.ts',


### PR DESCRIPTION
## Summary

- Add notification domain model with email log schema for tracking sent emails
- Implement email service abstraction with Console (dev) and Resend (production) implementations
- Create HTML/Text email templates for all CFP notification types
- Add email log repository for persistence
- Implement SendNotification use case for orchestrating email delivery
- Add 14 tests for notification domain with 100% coverage

### Notification Types
- `submission_confirmed` - Sent when a talk is submitted
- `talk_accepted` - Sent when a talk is accepted
- `talk_rejected` - Sent when a talk is rejected
- `confirmation_reminder` - Reminder for speakers to confirm attendance
- `cfp_closing_reminder` - Reminder that CFP is closing soon

## Test plan
- [x] All 141 tests pass
- [x] 100% code coverage on domain models
- [x] Email templates render correctly with placeholder data
- [x] Lint passes

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)